### PR TITLE
remove brackets from module name when comparing

### DIFF
--- a/dumper/src/chain.rs
+++ b/dumper/src/chain.rs
@@ -93,7 +93,7 @@ fn find_base_address<P: ProcessInfo>(proc: &P, name: &str, index: usize) -> Opti
             let name = Path::new(name).file_name().and_then(|s| s.to_str()).unwrap_or(name);
             Module { start, end, name }
         })
-        .filter(|x| x.name.eq(name))
+        .filter(|x| x.name.replace("[", "").replace("]", "").eq(name))
         .nth(index)
         .map(|x| x.start)
 }


### PR DESCRIPTION
I've noted that some returned modules name includes brackets, i.ex: [heap] and [stack].
And, for example, the comparison fails between "[heap]" (fetched module name) and "heap" (user parsed argument value).

So, to fix that i just added .replace().